### PR TITLE
Fix(defaults): default paths and index.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-resolver-codegen",
-  "version": "0.1.0",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-resolver-codegen",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Generate resolver types based on a GraphQL Schema",
   "main": "dist/index.js",
   "bin": {

--- a/src/generators/ts-scaffolder.ts
+++ b/src/generators/ts-scaffolder.ts
@@ -178,5 +178,25 @@ export interface Types extends ITypes {
     `
   });
 
+  files.push({
+    path: "index.ts",
+    force: false,
+    code: `
+    import { IResolvers } from '[TEMPLATE-INTERFACES-PATH]'
+    import { Types } from './types'
+    ${args.types
+      .map(
+        type => `
+      import { ${type.name} } from './${type.name}'
+    `
+      )
+      .join(";")}
+
+    export const resolvers: IResolvers<Types> = {
+      ${args.types.map(type => `${type.name}`).join(",")}   
+    }
+    `
+  });
+
   return files;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,8 @@ type CLIArgs = {
 };
 
 type DefaultOptions = {
-  output: string;
+  outputInterfaces: string;
+  outputScaffold: string;
   generator: GeneratorType;
   interfaces: string;
   force: boolean;
@@ -116,9 +117,10 @@ export function generateCode({
 
 async function run() {
   const defaults: DefaultOptions = {
-    output: "./generated/resolvers",
+    outputInterfaces: "src/generated/resolvers.ts",
+    outputScaffold: "src/resolvers/",
     generator: "typescript",
-    interfaces: "./generated/",
+    interfaces: "../generated/resolvers.ts",
     force: false
   };
   const argv = yargs
@@ -128,7 +130,10 @@ async function run() {
     .alias("s", "schema-path")
     .describe("s", "GraphQL schema file path")
     .alias("o", "output")
-    .describe("o", `Output file/folder path [default: ${defaults.output}[.ts]]`)
+    .describe(
+      "o",
+      `Output file/folder path [default: ${defaults.outputInterfaces}]`
+    )
     .alias("g", "generator")
     .describe(
       "g",
@@ -156,7 +161,11 @@ async function run() {
     schemaPath: resolve(argv.schemaPath),
     output:
       argv.output ||
-      `${defaults.output}${command === "interfaces" ? ".ts" : ""}`,
+      `${
+        command === "interfaces"
+          ? `${defaults.outputInterfaces}`
+          : `${defaults.outputScaffold}`
+      }`,
     generator: argv.generator || defaults.generator,
     interfaces: (argv.interfaces || defaults.interfaces)
       .trim()

--- a/src/tests/scaffold-typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/scaffold-typescript/__snapshots__/basic.test.ts.snap
@@ -47,6 +47,19 @@ export interface Types extends ITypes {
     "force": true,
     "path": "types.ts",
   },
+  Object {
+    "code": "import { IResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { Types } from \\"./types\\";
+
+import { User } from \\"./User\\";
+
+export const resolvers: IResolvers<Types> = {
+  User
+};
+",
+    "force": false,
+    "path": "index.ts",
+  },
 ]
 `;
 
@@ -127,6 +140,21 @@ export interface Types extends ITypes {
 ",
     "force": true,
     "path": "types.ts",
+  },
+  Object {
+    "code": "import { IResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { Types } from \\"./types\\";
+
+import { Query } from \\"./Query\\";
+import { Number } from \\"./Number\\";
+
+export const resolvers: IResolvers<Types> = {
+  Query,
+  Number
+};
+",
+    "force": false,
+    "path": "index.ts",
   },
 ]
 `;
@@ -214,6 +242,23 @@ export interface Types extends ITypes {
 ",
     "force": true,
     "path": "types.ts",
+  },
+  Object {
+    "code": "import { IResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { Types } from \\"./types\\";
+
+import { User } from \\"./User\\";
+import { Student } from \\"./Student\\";
+import { Professor } from \\"./Professor\\";
+
+export const resolvers: IResolvers<Types> = {
+  User,
+  Student,
+  Professor
+};
+",
+    "force": false,
+    "path": "index.ts",
   },
 ]
 `;

--- a/src/tests/scaffold-typescript/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/scaffold-typescript/__snapshots__/large-schema.test.ts.snap
@@ -1007,5 +1007,76 @@ export interface Types extends ITypes {
     "force": true,
     "path": "types.ts",
   },
+  Object {
+    "code": "import { IResolvers } from \\"[TEMPLATE-INTERFACES-PATH]\\";
+import { Types } from \\"./types\\";
+
+import { Query } from \\"./Query\\";
+import { Mutation } from \\"./Mutation\\";
+import { Viewer } from \\"./Viewer\\";
+import { AuthPayload } from \\"./AuthPayload\\";
+import { MutationResult } from \\"./MutationResult\\";
+import { ExperiencesByCity } from \\"./ExperiencesByCity\\";
+import { Home } from \\"./Home\\";
+import { Reservation } from \\"./Reservation\\";
+import { Experience } from \\"./Experience\\";
+import { Review } from \\"./Review\\";
+import { Neighbourhood } from \\"./Neighbourhood\\";
+import { Location } from \\"./Location\\";
+import { Picture } from \\"./Picture\\";
+import { City } from \\"./City\\";
+import { ExperienceCategory } from \\"./ExperienceCategory\\";
+import { User } from \\"./User\\";
+import { PaymentAccount } from \\"./PaymentAccount\\";
+import { Place } from \\"./Place\\";
+import { Booking } from \\"./Booking\\";
+import { Notification } from \\"./Notification\\";
+import { Payment } from \\"./Payment\\";
+import { PaypalInformation } from \\"./PaypalInformation\\";
+import { CreditCardInformation } from \\"./CreditCardInformation\\";
+import { Message } from \\"./Message\\";
+import { Pricing } from \\"./Pricing\\";
+import { PlaceViews } from \\"./PlaceViews\\";
+import { GuestRequirements } from \\"./GuestRequirements\\";
+import { Policies } from \\"./Policies\\";
+import { HouseRules } from \\"./HouseRules\\";
+import { Amenities } from \\"./Amenities\\";
+
+export const resolvers: IResolvers<Types> = {
+  Query,
+  Mutation,
+  Viewer,
+  AuthPayload,
+  MutationResult,
+  ExperiencesByCity,
+  Home,
+  Reservation,
+  Experience,
+  Review,
+  Neighbourhood,
+  Location,
+  Picture,
+  City,
+  ExperienceCategory,
+  User,
+  PaymentAccount,
+  Place,
+  Booking,
+  Notification,
+  Payment,
+  PaypalInformation,
+  CreditCardInformation,
+  Message,
+  Pricing,
+  PlaceViews,
+  GuestRequirements,
+  Policies,
+  HouseRules,
+  Amenities
+};
+",
+    "force": false,
+    "path": "index.ts",
+  },
 ]
 `;

--- a/src/tests/scaffold-typescript/basic.test.ts
+++ b/src/tests/scaffold-typescript/basic.test.ts
@@ -13,7 +13,7 @@ test("basic schema", async () => {
     schema: parsedSchema,
     generator: "scaffold-typescript"
   });
-  expect(code.length).toBe(4);
+  expect(code.length).toBe(5);
   expect(code).toMatchSnapshot();
 });
 
@@ -27,7 +27,7 @@ test("basic enum", async () => {
     schema: parsedSchema,
     generator: "scaffold-typescript"
   });
-  expect(code.length).toBe(3);
+  expect(code.length).toBe(4);
   expect(code).toMatchSnapshot();
 });
 
@@ -41,6 +41,6 @@ test("basic union", async () => {
     schema: parsedSchema,
     generator: "scaffold-typescript"
   });
-  expect(code.length).toBe(5);
+  expect(code.length).toBe(6);
   expect(code).toMatchSnapshot();
 });

--- a/src/tests/scaffold-typescript/large-schema.test.ts
+++ b/src/tests/scaffold-typescript/large-schema.test.ts
@@ -13,6 +13,6 @@ test("large schema", async () => {
     schema: parsedSchema,
     generator: "scaffold-typescript"
   });
-  expect(code.length).toBe(32);
+  expect(code.length).toBe(33);
   expect(code).toMatchSnapshot();
 });


### PR DESCRIPTION
This PR adds scaffolding of `index.ts`. 

Adds the defaults:
interfaces: `src/generated/resolvers.ts`
resolvers: `src/resolvers`