### PR TITLE
make npmignore work as it should

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
 *
 !dist/*.*
-!dist/generators
+!dist/generators/*.*


### PR DESCRIPTION
`dist/generators` dir was missing... oops, so sorry

![image](https://user-images.githubusercontent.com/383212/45998840-564f3080-c0a4-11e8-8607-f5ea33d56e44.png)

Now it is fine, tested locally by running `yarn pack`, see:

![image](https://user-images.githubusercontent.com/383212/45998966-aded9c00-c0a4-11e8-8065-94a3467ab8c1.png)

