### PR TITLE
fix(typescript): interfaces generation

### DIFF
--- a/src/generators/ts-generator.ts
+++ b/src/generators/ts-generator.ts
@@ -108,7 +108,7 @@ ${args.types
           : ""
       }
 
-  export type ${capitalize(field.name)}Type<T extends ITypeMap> = (
+  export type ${capitalize(field.name)}Resolver<T extends ITypeMap> = (
     parent: T['${type.name}${
         type.type.isEnum || type.type.isUnion ? "" : "Parent"
       }'],

--- a/src/generators/ts-generator.ts
+++ b/src/generators/ts-generator.ts
@@ -1,71 +1,102 @@
-import * as os from "os";
-import * as capitalize from "capitalize";
-import * as prettier from "prettier";
+import * as os from 'os'
+import * as capitalize from 'capitalize'
+import * as prettier from 'prettier'
 
-import { GenerateArgs } from "./generator-interface";
-import { GraphQLTypeField } from "../source-helper";
+import { GenerateArgs } from './generator-interface'
+import { GraphQLTypeField, GraphQLTypeObject } from '../source-helper'
 
-type SpecificGraphQLScalarType = "boolean" | "number" | "string";
+type SpecificGraphQLScalarType = 'boolean' | 'number' | 'string'
 
 function getTypeFromGraphQLType(type: string): SpecificGraphQLScalarType {
-  if (type === "Int" || type === "Float") {
-    return "number";
+  if (type === 'Int' || type === 'Float') {
+    return 'number'
   }
-  if (type === "Boolean") {
-    return "boolean";
+  if (type === 'Boolean') {
+    return 'boolean'
   }
-  if (type === "String" || type === "ID" || type === "DateTime") {
-    return "string";
+  if (type === 'String' || type === 'ID' || type === 'DateTime') {
+    return 'string'
   }
-  return "string";
+  return 'string'
 }
 
 export function format(code: string, options: prettier.Options = {}) {
   try {
     return prettier.format(code, {
       ...options,
-      parser: "typescript"
-    });
+      parser: 'typescript',
+    })
   } catch (e) {
     console.log(
       `There is a syntax error in generated code, unformatted code printed, error: ${JSON.stringify(
-        e
-      )}`
-    );
-    return code;
+        e,
+      )}`,
+    )
+    return code
   }
 }
 
 export function printFieldLikeType(
   field: GraphQLTypeField,
-  lookupType: boolean = true
+  lookupType: boolean = true,
 ) {
   if (field.type.isScalar) {
     return `${getTypeFromGraphQLType(field.type.name)}${
-      field.type.isArray ? "[]" : ""
-    }${!field.type.isRequired ? "| null" : ""}`;
+      field.type.isArray ? '[]' : ''
+    }${!field.type.isRequired ? '| null' : ''}`
   }
 
   if (field.type.isInput) {
-    return `${field.type.name}${field.type.isArray ? "[]" : ""}${
-      !field.type.isRequired ? "| null" : ""
-    }`;
+    return `${field.type.name}${field.type.isArray ? '[]' : ''}${
+      !field.type.isRequired ? '| null' : ''
+    }`
   }
 
   return lookupType
     ? `T['${field.type.name}${
-        field.type.isEnum || field.type.isUnion ? "" : "Parent"
-      }']${field.type.isArray ? "[]" : ""}${
-        !field.type.isRequired ? "| null" : ""
+        field.type.isEnum || field.type.isUnion ? '' : 'Parent'
+      }']${field.type.isArray ? '[]' : ''}${
+        !field.type.isRequired ? '| null' : ''
       }`
     : `${field.type.name}${
-        field.type.isEnum || field.type.isUnion ? "" : "Parent"
-      }${field.type.isArray ? "[]" : ""}${
-        !field.type.isRequired ? "| null" : ""
-      }`;
+        field.type.isEnum || field.type.isUnion ? '' : 'Parent'
+      }${field.type.isArray ? '[]' : ''}${
+        !field.type.isRequired ? '| null' : ''
+      }`
 }
 
 export function generate(args: GenerateArgs) {
+  // TODO: Maybe move this to source helper
+  const inputTypesMap: { [s: string]: GraphQLTypeObject } = args.types
+    .filter(type => type.type.isInput)
+    .reduce((inputTypes, type) => {
+      return {
+        ...inputTypes,
+        [`${type.name}`]: type,
+      }
+    }, {})
+
+  // TODO: Type this
+  const typeToInputTypeAssociation: {[s: string]: any} = args.types
+    .filter(
+      type =>
+        type.type.isObject &&
+        type.fields.filter(
+          field => field.arguments.filter(arg => arg.type.isInput).length > 0,
+        ).length > 0,
+    )
+    .reduce((types, type) => {
+      return {
+        ...types,
+        [`${type.name}`]: [].concat(...type.fields.map(field =>
+          field.arguments
+            .filter(arg => arg.type.isInput)
+            .map(arg => arg.type.name),
+        ) as any)
+      }
+    }, {})
+  console.log(inputTypesMap, typeToInputTypeAssociation)
+
   return `
 import { GraphQLResolveInfo } from 'graphql'
 
@@ -84,17 +115,11 @@ ${args.types
     .map(
       type => `export namespace ${type.name}Resolvers {
 
-        ${args.types
-          .filter(type => type.type.isInput)
-          .map(
-            type => ` // Input type
-            export interface ${type.name} {
-          ${type.fields.map(
+        ${typeToInputTypeAssociation[type.name] ? `export interface ${inputTypesMap[typeToInputTypeAssociation[type.name]].name} {
+          ${inputTypesMap[typeToInputTypeAssociation[type.name]].fields.map(
             field => `${field.name}: ${getTypeFromGraphQLType(field.type.name)}`
           )}
-        }`
-          )
-          .join(os.EOL)}
+        }` : ``}  
 
   ${type.fields
     .map(
@@ -103,24 +128,24 @@ ${args.types
           ? `export interface Args${capitalize(field.name)} {
       ${field.arguments
         .map(
-          arg => `${arg.name}: ${printFieldLikeType(arg as GraphQLTypeField)}`
+          arg => `${arg.name}: ${printFieldLikeType(arg as GraphQLTypeField)}`,
         )
         .join(os.EOL)}
     }`
-          : ""
+          : ''
       }
 
   export type ${capitalize(field.name)}Resolver<T extends ITypeMap> = (
     parent: T['${type.name}${
-        type.type.isEnum || type.type.isUnion ? "" : "Parent"
+        type.type.isEnum || type.type.isUnion ? '' : 'Parent'
       }'],
     args: ${
-      field.arguments.length > 0 ? `Args${capitalize(field.name)}` : "{}"
+      field.arguments.length > 0 ? `Args${capitalize(field.name)}` : '{}'
     },
     ctx: T['Context'],
     info: GraphQLResolveInfo,
   ) => ${printFieldLikeType(field)} | Promise<${printFieldLikeType(field)}>
-  `
+  `,
     )
     .join(os.EOL)}
 
@@ -129,19 +154,19 @@ ${args.types
     .map(
       field => `${field.name}: (
       parent: T['${type.name}${
-        type.type.isEnum || type.type.isUnion ? "" : "Parent"
+        type.type.isEnum || type.type.isUnion ? '' : 'Parent'
       }'],
       args: ${
-        field.arguments.length > 0 ? `Args${capitalize(field.name)}` : "{}"
+        field.arguments.length > 0 ? `Args${capitalize(field.name)}` : '{}'
       },
       ctx: T['Context'],
       info: GraphQLResolveInfo,
-    ) => ${printFieldLikeType(field)} | Promise<${printFieldLikeType(field)}>`
+    ) => ${printFieldLikeType(field)} | Promise<${printFieldLikeType(field)}>`,
     )
     .join(os.EOL)}
   }
 }
-`
+`,
     )
     .join(os.EOL)}
 
@@ -152,5 +177,5 @@ export interface IResolvers<T extends ITypeMap> {
     .join(os.EOL)}
 }
 
-  `;
+  `
 }

--- a/src/generators/ts-generator.ts
+++ b/src/generators/ts-generator.ts
@@ -80,20 +80,22 @@ ${args.types
 }
 
   ${args.types
-    .filter(type => type.type.isInput)
-    .map(
-      type => `export interface ${type.name} {
-    ${type.fields.map(
-      field => `${field.name}: ${getTypeFromGraphQLType(field.type.name)}`
-    )}
-  }`
-    )
-    .join(os.EOL)}
-
-  ${args.types
     .filter(type => type.type.isObject)
     .map(
       type => `export namespace ${type.name}Resolvers {
+
+        ${args.types
+          .filter(type => type.type.isInput)
+          .map(
+            type => ` // Input type
+            export interface ${type.name} {
+          ${type.fields.map(
+            field => `${field.name}: ${getTypeFromGraphQLType(field.type.name)}`
+          )}
+        }`
+          )
+          .join(os.EOL)}
+
   ${type.fields
     .map(
       field => `${

--- a/src/generators/ts-generator.ts
+++ b/src/generators/ts-generator.ts
@@ -95,7 +95,6 @@ export function generate(args: GenerateArgs) {
         ) as any)
       }
     }, {})
-  console.log(inputTypesMap, typeToInputTypeAssociation)
 
   return `
 import { GraphQLResolveInfo } from 'graphql'

--- a/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -71,12 +71,6 @@ export interface ITypeMap {
 }
 
 export namespace AddMemberPayloadResolvers {
-  // Input type
-  export interface AddMemberData {
-    email: string;
-    projects: string;
-  }
-
   export type NewUserIdResolver<T extends ITypeMap> = (
     parent: T[\\"AddMemberPayloadParent\\"],
     args: {},
@@ -108,7 +102,6 @@ export namespace AddMemberPayloadResolvers {
 }
 
 export namespace MutationResolvers {
-  // Input type
   export interface AddMemberData {
     email: string;
     projects: string;
@@ -153,12 +146,6 @@ export interface ITypeMap {
 }
 
 export namespace AddMemberPayloadResolvers {
-  // Input type
-  export interface AddMemberData {
-    email: string;
-    projects: string;
-  }
-
   export type JsonResolver<T extends ITypeMap> = (
     parent: T[\\"AddMemberPayloadParent\\"],
     args: {},
@@ -177,7 +164,6 @@ export namespace AddMemberPayloadResolvers {
 }
 
 export namespace MutationResolvers {
-  // Input type
   export interface AddMemberData {
     email: string;
     projects: string;

--- a/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -11,21 +11,21 @@ export interface ITypeMap {
 }
 
 export namespace UserResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type NameType<T extends ITypeMap> = (
+  export type NameResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type TypeType<T extends ITypeMap> = (
+  export type TypeResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -76,14 +76,14 @@ export interface AddMemberData {
 }
 
 export namespace AddMemberPayloadResolvers {
-  export type NewUserIdType<T extends ITypeMap> = (
+  export type NewUserIdResolver<T extends ITypeMap> = (
     parent: T[\\"AddMemberPayloadParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
-  export type ExistingUserInviteSentType<T extends ITypeMap> = (
+  export type ExistingUserInviteSentResolver<T extends ITypeMap> = (
     parent: T[\\"AddMemberPayloadParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -111,7 +111,7 @@ export namespace MutationResolvers {
     data: AddMemberData;
   }
 
-  export type AddMemberType<T extends ITypeMap> = (
+  export type AddMemberResolver<T extends ITypeMap> = (
     parent: T[\\"MutationParent\\"],
     args: ArgsAddMember,
     ctx: T[\\"Context\\"],
@@ -151,7 +151,7 @@ export interface AddMemberData {
 }
 
 export namespace AddMemberPayloadResolvers {
-  export type JsonType<T extends ITypeMap> = (
+  export type JsonResolver<T extends ITypeMap> = (
     parent: T[\\"AddMemberPayloadParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -173,7 +173,7 @@ export namespace MutationResolvers {
     data: AddMemberData;
   }
 
-  export type AddMemberType<T extends ITypeMap> = (
+  export type AddMemberResolver<T extends ITypeMap> = (
     parent: T[\\"MutationParent\\"],
     args: ArgsAddMember,
     ctx: T[\\"Context\\"],
@@ -208,35 +208,35 @@ export interface ITypeMap {
 }
 
 export namespace QueryResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type Custom_requiredType<T extends ITypeMap> = (
+  export type Custom_requiredResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"NumberParent\\"] | Promise<T[\\"NumberParent\\"]>;
 
-  export type Custom_nullableType<T extends ITypeMap> = (
+  export type Custom_nullableResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"NumberParent\\"] | null | Promise<T[\\"NumberParent\\"] | null>;
 
-  export type Custom_array_nullableType<T extends ITypeMap> = (
+  export type Custom_array_nullableResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"NumberParent\\"][] | null | Promise<T[\\"NumberParent\\"][] | null>;
 
-  export type Custom_array_requiredType<T extends ITypeMap> = (
+  export type Custom_array_requiredResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -247,7 +247,7 @@ export namespace QueryResolvers {
     id: number;
   }
 
-  export type Custom_with_argType<T extends ITypeMap> = (
+  export type Custom_with_argResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: ArgsCustom_with_arg,
     ctx: T[\\"Context\\"],
@@ -258,35 +258,35 @@ export namespace QueryResolvers {
     id: T[\\"NumberParent\\"];
   }
 
-  export type Custom_with_custom_argType<T extends ITypeMap> = (
+  export type Custom_with_custom_argResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: ArgsCustom_with_custom_arg,
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"NumberParent\\"] | Promise<T[\\"NumberParent\\"]>;
 
-  export type Scalar_requiredType<T extends ITypeMap> = (
+  export type Scalar_requiredResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type Scalar_nullableType<T extends ITypeMap> = (
+  export type Scalar_nullableResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
-  export type Scalar_array_nullableType<T extends ITypeMap> = (
+  export type Scalar_array_nullableResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean[] | null | Promise<boolean[] | null>;
 
-  export type Scalar_array_requiredType<T extends ITypeMap> = (
+  export type Scalar_array_requiredResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -297,7 +297,7 @@ export namespace QueryResolvers {
     id: number;
   }
 
-  export type Scalar_with_argType<T extends ITypeMap> = (
+  export type Scalar_with_argResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: ArgsScalar_with_arg,
     ctx: T[\\"Context\\"],
@@ -308,7 +308,7 @@ export namespace QueryResolvers {
     id: T[\\"NumberParent\\"];
   }
 
-  export type Scalar_with_custom_argType<T extends ITypeMap> = (
+  export type Scalar_with_custom_argResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: ArgsScalar_with_custom_arg,
     ctx: T[\\"Context\\"],
@@ -398,14 +398,14 @@ export namespace QueryResolvers {
 }
 
 export namespace NumberResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"NumberParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
-  export type ValueType<T extends ITypeMap> = (
+  export type ValueResolver<T extends ITypeMap> = (
     parent: T[\\"NumberParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -448,21 +448,21 @@ export interface ITypeMap {
 }
 
 export namespace UserResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type NameType<T extends ITypeMap> = (
+  export type NameResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type TypeType<T extends ITypeMap> = (
+  export type TypeResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -492,7 +492,7 @@ export namespace UserResolvers {
 }
 
 export namespace StudentResolvers {
-  export type AgeType<T extends ITypeMap> = (
+  export type AgeResolver<T extends ITypeMap> = (
     parent: T[\\"StudentParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -510,7 +510,7 @@ export namespace StudentResolvers {
 }
 
 export namespace ProfessorResolvers {
-  export type DegreeType<T extends ITypeMap> = (
+  export type DegreeResolver<T extends ITypeMap> = (
     parent: T[\\"ProfessorParent\\"],
     args: {},
     ctx: T[\\"Context\\"],

--- a/src/tests/typescript/__snapshots__/basic.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/basic.test.ts.snap
@@ -70,12 +70,13 @@ export interface ITypeMap {
   MutationParent: any;
 }
 
-export interface AddMemberData {
-  email: string;
-  projects: string;
-}
-
 export namespace AddMemberPayloadResolvers {
+  // Input type
+  export interface AddMemberData {
+    email: string;
+    projects: string;
+  }
+
   export type NewUserIdResolver<T extends ITypeMap> = (
     parent: T[\\"AddMemberPayloadParent\\"],
     args: {},
@@ -107,6 +108,12 @@ export namespace AddMemberPayloadResolvers {
 }
 
 export namespace MutationResolvers {
+  // Input type
+  export interface AddMemberData {
+    email: string;
+    projects: string;
+  }
+
   export interface ArgsAddMember {
     data: AddMemberData;
   }
@@ -145,12 +152,13 @@ export interface ITypeMap {
   MutationParent: any;
 }
 
-export interface AddMemberData {
-  email: string;
-  projects: string;
-}
-
 export namespace AddMemberPayloadResolvers {
+  // Input type
+  export interface AddMemberData {
+    email: string;
+    projects: string;
+  }
+
   export type JsonResolver<T extends ITypeMap> = (
     parent: T[\\"AddMemberPayloadParent\\"],
     args: {},
@@ -169,6 +177,12 @@ export namespace AddMemberPayloadResolvers {
 }
 
 export namespace MutationResolvers {
+  // Input type
+  export interface AddMemberData {
+    email: string;
+    projects: string;
+  }
+
   export interface ArgsAddMember {
     data: AddMemberData;
   }

--- a/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
+++ b/src/tests/typescript/__snapshots__/large-schema.test.ts.snap
@@ -39,14 +39,14 @@ export interface ITypeMap {
 }
 
 export namespace QueryResolvers {
-  export type TopExperiencesType<T extends ITypeMap> = (
+  export type TopExperiencesResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"ExperienceParent\\"][] | Promise<T[\\"ExperienceParent\\"][]>;
 
-  export type TopHomesType<T extends ITypeMap> = (
+  export type TopHomesResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -58,21 +58,21 @@ export namespace QueryResolvers {
     max: number;
   }
 
-  export type HomesInPriceRangeType<T extends ITypeMap> = (
+  export type HomesInPriceRangeResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: ArgsHomesInPriceRange,
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"HomeParent\\"][] | Promise<T[\\"HomeParent\\"][]>;
 
-  export type TopReservationsType<T extends ITypeMap> = (
+  export type TopReservationsResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"ReservationParent\\"][] | Promise<T[\\"ReservationParent\\"][]>;
 
-  export type FeaturedDestinationsType<T extends ITypeMap> = (
+  export type FeaturedDestinationsResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -83,21 +83,21 @@ export namespace QueryResolvers {
     cities: string[];
   }
 
-  export type ExperiencesByCityType<T extends ITypeMap> = (
+  export type ExperiencesByCityResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: ArgsExperiencesByCity,
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"ExperiencesByCityParent\\"][] | Promise<T[\\"ExperiencesByCityParent\\"][]>;
 
-  export type ViewerType<T extends ITypeMap> = (
+  export type ViewerResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"ViewerParent\\"] | null | Promise<T[\\"ViewerParent\\"] | null>;
 
-  export type MyLocationType<T extends ITypeMap> = (
+  export type MyLocationResolver<T extends ITypeMap> = (
     parent: T[\\"QueryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -167,7 +167,7 @@ export namespace MutationResolvers {
     phone: string;
   }
 
-  export type SignupType<T extends ITypeMap> = (
+  export type SignupResolver<T extends ITypeMap> = (
     parent: T[\\"MutationParent\\"],
     args: ArgsSignup,
     ctx: T[\\"Context\\"],
@@ -179,7 +179,7 @@ export namespace MutationResolvers {
     password: string;
   }
 
-  export type LoginType<T extends ITypeMap> = (
+  export type LoginResolver<T extends ITypeMap> = (
     parent: T[\\"MutationParent\\"],
     args: ArgsLogin,
     ctx: T[\\"Context\\"],
@@ -197,7 +197,7 @@ export namespace MutationResolvers {
     country: string;
   }
 
-  export type AddPaymentMethodType<T extends ITypeMap> = (
+  export type AddPaymentMethodResolver<T extends ITypeMap> = (
     parent: T[\\"MutationParent\\"],
     args: ArgsAddPaymentMethod,
     ctx: T[\\"Context\\"],
@@ -211,7 +211,7 @@ export namespace MutationResolvers {
     numGuests: number;
   }
 
-  export type BookType<T extends ITypeMap> = (
+  export type BookResolver<T extends ITypeMap> = (
     parent: T[\\"MutationParent\\"],
     args: ArgsBook,
     ctx: T[\\"Context\\"],
@@ -247,14 +247,14 @@ export namespace MutationResolvers {
 }
 
 export namespace ViewerResolvers {
-  export type MeType<T extends ITypeMap> = (
+  export type MeResolver<T extends ITypeMap> = (
     parent: T[\\"ViewerParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"UserParent\\"] | Promise<T[\\"UserParent\\"]>;
 
-  export type BookingsType<T extends ITypeMap> = (
+  export type BookingsResolver<T extends ITypeMap> = (
     parent: T[\\"ViewerParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -278,14 +278,14 @@ export namespace ViewerResolvers {
 }
 
 export namespace AuthPayloadResolvers {
-  export type TokenType<T extends ITypeMap> = (
+  export type TokenResolver<T extends ITypeMap> = (
     parent: T[\\"AuthPayloadParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type UserType<T extends ITypeMap> = (
+  export type UserResolver<T extends ITypeMap> = (
     parent: T[\\"AuthPayloadParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -309,7 +309,7 @@ export namespace AuthPayloadResolvers {
 }
 
 export namespace MutationResultResolvers {
-  export type SuccessType<T extends ITypeMap> = (
+  export type SuccessResolver<T extends ITypeMap> = (
     parent: T[\\"MutationResultParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -327,14 +327,14 @@ export namespace MutationResultResolvers {
 }
 
 export namespace ExperiencesByCityResolvers {
-  export type ExperiencesType<T extends ITypeMap> = (
+  export type ExperiencesResolver<T extends ITypeMap> = (
     parent: T[\\"ExperiencesByCityParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"ExperienceParent\\"][] | Promise<T[\\"ExperienceParent\\"][]>;
 
-  export type CityType<T extends ITypeMap> = (
+  export type CityResolver<T extends ITypeMap> = (
     parent: T[\\"ExperiencesByCityParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -358,35 +358,35 @@ export namespace ExperiencesByCityResolvers {
 }
 
 export namespace HomeResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type NameType<T extends ITypeMap> = (
+  export type NameResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
-  export type DescriptionType<T extends ITypeMap> = (
+  export type DescriptionResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type NumRatingsType<T extends ITypeMap> = (
+  export type NumRatingsResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type AvgRatingType<T extends ITypeMap> = (
+  export type AvgRatingResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -397,14 +397,14 @@ export namespace HomeResolvers {
     first: number | null;
   }
 
-  export type PicturesType<T extends ITypeMap> = (
+  export type PicturesResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
     args: ArgsPictures,
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PictureParent\\"][] | Promise<T[\\"PictureParent\\"][]>;
 
-  export type PerNightType<T extends ITypeMap> = (
+  export type PerNightResolver<T extends ITypeMap> = (
     parent: T[\\"HomeParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -458,56 +458,56 @@ export namespace HomeResolvers {
 }
 
 export namespace ReservationResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"ReservationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type TitleType<T extends ITypeMap> = (
+  export type TitleResolver<T extends ITypeMap> = (
     parent: T[\\"ReservationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type AvgPricePerPersonType<T extends ITypeMap> = (
+  export type AvgPricePerPersonResolver<T extends ITypeMap> = (
     parent: T[\\"ReservationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type PicturesType<T extends ITypeMap> = (
+  export type PicturesResolver<T extends ITypeMap> = (
     parent: T[\\"ReservationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PictureParent\\"][] | Promise<T[\\"PictureParent\\"][]>;
 
-  export type LocationType<T extends ITypeMap> = (
+  export type LocationResolver<T extends ITypeMap> = (
     parent: T[\\"ReservationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"LocationParent\\"] | Promise<T[\\"LocationParent\\"]>;
 
-  export type IsCuratedType<T extends ITypeMap> = (
+  export type IsCuratedResolver<T extends ITypeMap> = (
     parent: T[\\"ReservationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type SlugType<T extends ITypeMap> = (
+  export type SlugResolver<T extends ITypeMap> = (
     parent: T[\\"ReservationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type PopularityType<T extends ITypeMap> = (
+  export type PopularityResolver<T extends ITypeMap> = (
     parent: T[\\"ReservationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -567,14 +567,14 @@ export namespace ReservationResolvers {
 }
 
 export namespace ExperienceResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type CategoryType<T extends ITypeMap> = (
+  export type CategoryResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -584,42 +584,42 @@ export namespace ExperienceResolvers {
     | null
     | Promise<T[\\"ExperienceCategoryParent\\"] | null>;
 
-  export type TitleType<T extends ITypeMap> = (
+  export type TitleResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type LocationType<T extends ITypeMap> = (
+  export type LocationResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"LocationParent\\"] | Promise<T[\\"LocationParent\\"]>;
 
-  export type PricePerPersonType<T extends ITypeMap> = (
+  export type PricePerPersonResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type ReviewsType<T extends ITypeMap> = (
+  export type ReviewsResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"ReviewParent\\"][] | Promise<T[\\"ReviewParent\\"][]>;
 
-  export type PreviewType<T extends ITypeMap> = (
+  export type PreviewResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PictureParent\\"] | Promise<T[\\"PictureParent\\"]>;
 
-  export type PopularityType<T extends ITypeMap> = (
+  export type PopularityResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -682,70 +682,70 @@ export namespace ExperienceResolvers {
 }
 
 export namespace ReviewResolvers {
-  export type AccuracyType<T extends ITypeMap> = (
+  export type AccuracyResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type CheckInType<T extends ITypeMap> = (
+  export type CheckInResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type CleanlinessType<T extends ITypeMap> = (
+  export type CleanlinessResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type CommunicationType<T extends ITypeMap> = (
+  export type CommunicationResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type LocationType<T extends ITypeMap> = (
+  export type LocationResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type StarsType<T extends ITypeMap> = (
+  export type StarsResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type TextType<T extends ITypeMap> = (
+  export type TextResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type ValueType<T extends ITypeMap> = (
+  export type ValueResolver<T extends ITypeMap> = (
     parent: T[\\"ReviewParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -817,49 +817,49 @@ export namespace ReviewResolvers {
 }
 
 export namespace NeighbourhoodResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"NeighbourhoodParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type NameType<T extends ITypeMap> = (
+  export type NameResolver<T extends ITypeMap> = (
     parent: T[\\"NeighbourhoodParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type SlugType<T extends ITypeMap> = (
+  export type SlugResolver<T extends ITypeMap> = (
     parent: T[\\"NeighbourhoodParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type HomePreviewType<T extends ITypeMap> = (
+  export type HomePreviewResolver<T extends ITypeMap> = (
     parent: T[\\"NeighbourhoodParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PictureParent\\"] | null | Promise<T[\\"PictureParent\\"] | null>;
 
-  export type CityType<T extends ITypeMap> = (
+  export type CityResolver<T extends ITypeMap> = (
     parent: T[\\"NeighbourhoodParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"CityParent\\"] | Promise<T[\\"CityParent\\"]>;
 
-  export type FeaturedType<T extends ITypeMap> = (
+  export type FeaturedResolver<T extends ITypeMap> = (
     parent: T[\\"NeighbourhoodParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type PopularityType<T extends ITypeMap> = (
+  export type PopularityResolver<T extends ITypeMap> = (
     parent: T[\\"NeighbourhoodParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -913,35 +913,35 @@ export namespace NeighbourhoodResolvers {
 }
 
 export namespace LocationResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"LocationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type LatType<T extends ITypeMap> = (
+  export type LatResolver<T extends ITypeMap> = (
     parent: T[\\"LocationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type LngType<T extends ITypeMap> = (
+  export type LngResolver<T extends ITypeMap> = (
     parent: T[\\"LocationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type AddressType<T extends ITypeMap> = (
+  export type AddressResolver<T extends ITypeMap> = (
     parent: T[\\"LocationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
-  export type DirectionsType<T extends ITypeMap> = (
+  export type DirectionsResolver<T extends ITypeMap> = (
     parent: T[\\"LocationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -983,14 +983,14 @@ export namespace LocationResolvers {
 }
 
 export namespace PictureResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PictureParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type UrlType<T extends ITypeMap> = (
+  export type UrlResolver<T extends ITypeMap> = (
     parent: T[\\"PictureParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1014,14 +1014,14 @@ export namespace PictureResolvers {
 }
 
 export namespace CityResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"CityParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type NameType<T extends ITypeMap> = (
+  export type NameResolver<T extends ITypeMap> = (
     parent: T[\\"CityParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1045,28 +1045,28 @@ export namespace CityResolvers {
 }
 
 export namespace ExperienceCategoryResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceCategoryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type MainColorType<T extends ITypeMap> = (
+  export type MainColorResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceCategoryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type NameType<T extends ITypeMap> = (
+  export type NameResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceCategoryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type ExperienceType<T extends ITypeMap> = (
+  export type ExperienceResolver<T extends ITypeMap> = (
     parent: T[\\"ExperienceCategoryParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1102,140 +1102,140 @@ export namespace ExperienceCategoryResolvers {
 }
 
 export namespace UserResolvers {
-  export type BookingsType<T extends ITypeMap> = (
+  export type BookingsResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"BookingParent\\"][] | Promise<T[\\"BookingParent\\"][]>;
 
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type EmailType<T extends ITypeMap> = (
+  export type EmailResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type FirstNameType<T extends ITypeMap> = (
+  export type FirstNameResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type HostingExperiencesType<T extends ITypeMap> = (
+  export type HostingExperiencesResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"ExperienceParent\\"][] | Promise<T[\\"ExperienceParent\\"][]>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type IsSuperHostType<T extends ITypeMap> = (
+  export type IsSuperHostResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type LastNameType<T extends ITypeMap> = (
+  export type LastNameResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type LocationType<T extends ITypeMap> = (
+  export type LocationResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"LocationParent\\"] | Promise<T[\\"LocationParent\\"]>;
 
-  export type NotificationsType<T extends ITypeMap> = (
+  export type NotificationsResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"NotificationParent\\"][] | Promise<T[\\"NotificationParent\\"][]>;
 
-  export type OwnedPlacesType<T extends ITypeMap> = (
+  export type OwnedPlacesResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PlaceParent\\"][] | Promise<T[\\"PlaceParent\\"][]>;
 
-  export type PaymentAccountType<T extends ITypeMap> = (
+  export type PaymentAccountResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PaymentAccountParent\\"][] | Promise<T[\\"PaymentAccountParent\\"][]>;
 
-  export type PhoneType<T extends ITypeMap> = (
+  export type PhoneResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type ProfilePictureType<T extends ITypeMap> = (
+  export type ProfilePictureResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PictureParent\\"] | null | Promise<T[\\"PictureParent\\"] | null>;
 
-  export type ReceivedMessagesType<T extends ITypeMap> = (
+  export type ReceivedMessagesResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"MessageParent\\"][] | Promise<T[\\"MessageParent\\"][]>;
 
-  export type ResponseRateType<T extends ITypeMap> = (
+  export type ResponseRateResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
-  export type ResponseTimeType<T extends ITypeMap> = (
+  export type ResponseTimeResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
-  export type SentMessagesType<T extends ITypeMap> = (
+  export type SentMessagesResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"MessageParent\\"][] | Promise<T[\\"MessageParent\\"][]>;
 
-  export type UpdatedAtType<T extends ITypeMap> = (
+  export type UpdatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type TokenType<T extends ITypeMap> = (
+  export type TokenResolver<T extends ITypeMap> = (
     parent: T[\\"UserParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1367,21 +1367,21 @@ export namespace UserResolvers {
 }
 
 export namespace PaymentAccountResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentAccountParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentAccountParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type TypeType<T extends ITypeMap> = (
+  export type TypeResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentAccountParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1391,21 +1391,21 @@ export namespace PaymentAccountResolvers {
     | null
     | Promise<T[\\"PAYMENT_PROVIDERParent\\"] | null>;
 
-  export type UserType<T extends ITypeMap> = (
+  export type UserResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentAccountParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"UserParent\\"] | Promise<T[\\"UserParent\\"]>;
 
-  export type PaymentsType<T extends ITypeMap> = (
+  export type PaymentsResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentAccountParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PaymentParent\\"][] | Promise<T[\\"PaymentParent\\"][]>;
 
-  export type PaypalType<T extends ITypeMap> = (
+  export type PaypalResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentAccountParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1415,7 +1415,7 @@ export namespace PaymentAccountResolvers {
     | null
     | Promise<T[\\"PaypalInformationParent\\"] | null>;
 
-  export type CreditcardType<T extends ITypeMap> = (
+  export type CreditcardResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentAccountParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1481,119 +1481,119 @@ export namespace PaymentAccountResolvers {
 }
 
 export namespace PlaceResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type NameType<T extends ITypeMap> = (
+  export type NameResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
-  export type SizeType<T extends ITypeMap> = (
+  export type SizeResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PLACE_SIZESParent\\"] | null | Promise<T[\\"PLACE_SIZESParent\\"] | null>;
 
-  export type ShortDescriptionType<T extends ITypeMap> = (
+  export type ShortDescriptionResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type DescriptionType<T extends ITypeMap> = (
+  export type DescriptionResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type SlugType<T extends ITypeMap> = (
+  export type SlugResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type MaxGuestsType<T extends ITypeMap> = (
+  export type MaxGuestsResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type NumBedroomsType<T extends ITypeMap> = (
+  export type NumBedroomsResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type NumBedsType<T extends ITypeMap> = (
+  export type NumBedsResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type NumBathsType<T extends ITypeMap> = (
+  export type NumBathsResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type ReviewsType<T extends ITypeMap> = (
+  export type ReviewsResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"ReviewParent\\"][] | Promise<T[\\"ReviewParent\\"][]>;
 
-  export type AmenitiesType<T extends ITypeMap> = (
+  export type AmenitiesResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"AmenitiesParent\\"] | Promise<T[\\"AmenitiesParent\\"]>;
 
-  export type HostType<T extends ITypeMap> = (
+  export type HostResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"UserParent\\"] | Promise<T[\\"UserParent\\"]>;
 
-  export type PricingType<T extends ITypeMap> = (
+  export type PricingResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PricingParent\\"] | Promise<T[\\"PricingParent\\"]>;
 
-  export type LocationType<T extends ITypeMap> = (
+  export type LocationResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"LocationParent\\"] | Promise<T[\\"LocationParent\\"]>;
 
-  export type ViewsType<T extends ITypeMap> = (
+  export type ViewsResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PlaceViewsParent\\"] | Promise<T[\\"PlaceViewsParent\\"]>;
 
-  export type GuestRequirementsType<T extends ITypeMap> = (
+  export type GuestRequirementsResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1603,35 +1603,35 @@ export namespace PlaceResolvers {
     | null
     | Promise<T[\\"GuestRequirementsParent\\"] | null>;
 
-  export type PoliciesType<T extends ITypeMap> = (
+  export type PoliciesResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PoliciesParent\\"] | null | Promise<T[\\"PoliciesParent\\"] | null>;
 
-  export type HouseRulesType<T extends ITypeMap> = (
+  export type HouseRulesResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"HouseRulesParent\\"] | null | Promise<T[\\"HouseRulesParent\\"] | null>;
 
-  export type BookingsType<T extends ITypeMap> = (
+  export type BookingsResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"BookingParent\\"][] | Promise<T[\\"BookingParent\\"][]>;
 
-  export type PicturesType<T extends ITypeMap> = (
+  export type PicturesResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PictureParent\\"][] | Promise<T[\\"PictureParent\\"][]>;
 
-  export type PopularityType<T extends ITypeMap> = (
+  export type PopularityResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1778,49 +1778,49 @@ export namespace PlaceResolvers {
 }
 
 export namespace BookingResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"BookingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"BookingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type BookeeType<T extends ITypeMap> = (
+  export type BookeeResolver<T extends ITypeMap> = (
     parent: T[\\"BookingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"UserParent\\"] | Promise<T[\\"UserParent\\"]>;
 
-  export type PlaceType<T extends ITypeMap> = (
+  export type PlaceResolver<T extends ITypeMap> = (
     parent: T[\\"BookingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PlaceParent\\"] | Promise<T[\\"PlaceParent\\"]>;
 
-  export type StartDateType<T extends ITypeMap> = (
+  export type StartDateResolver<T extends ITypeMap> = (
     parent: T[\\"BookingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type EndDateType<T extends ITypeMap> = (
+  export type EndDateResolver<T extends ITypeMap> = (
     parent: T[\\"BookingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type PaymentType<T extends ITypeMap> = (
+  export type PaymentResolver<T extends ITypeMap> = (
     parent: T[\\"BookingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1874,35 +1874,35 @@ export namespace BookingResolvers {
 }
 
 export namespace NotificationResolvers {
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"NotificationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"NotificationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type LinkType<T extends ITypeMap> = (
+  export type LinkResolver<T extends ITypeMap> = (
     parent: T[\\"NotificationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type ReadDateType<T extends ITypeMap> = (
+  export type ReadDateResolver<T extends ITypeMap> = (
     parent: T[\\"NotificationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type TypeType<T extends ITypeMap> = (
+  export type TypeResolver<T extends ITypeMap> = (
     parent: T[\\"NotificationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1912,7 +1912,7 @@ export namespace NotificationResolvers {
     | null
     | Promise<T[\\"NOTIFICATION_TYPEParent\\"] | null>;
 
-  export type UserType<T extends ITypeMap> = (
+  export type UserResolver<T extends ITypeMap> = (
     parent: T[\\"NotificationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -1963,35 +1963,35 @@ export namespace NotificationResolvers {
 }
 
 export namespace PaymentResolvers {
-  export type BookingType<T extends ITypeMap> = (
+  export type BookingResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"BookingParent\\"] | Promise<T[\\"BookingParent\\"]>;
 
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type PaymentMethodType<T extends ITypeMap> = (
+  export type PaymentMethodResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"PaymentAccountParent\\"] | Promise<T[\\"PaymentAccountParent\\"]>;
 
-  export type ServiceFeeType<T extends ITypeMap> = (
+  export type ServiceFeeResolver<T extends ITypeMap> = (
     parent: T[\\"PaymentParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2033,28 +2033,28 @@ export namespace PaymentResolvers {
 }
 
 export namespace PaypalInformationResolvers {
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"PaypalInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type EmailType<T extends ITypeMap> = (
+  export type EmailResolver<T extends ITypeMap> = (
     parent: T[\\"PaypalInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PaypalInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type PaymentAccountType<T extends ITypeMap> = (
+  export type PaymentAccountResolver<T extends ITypeMap> = (
     parent: T[\\"PaypalInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2090,63 +2090,63 @@ export namespace PaypalInformationResolvers {
 }
 
 export namespace CreditCardInformationResolvers {
-  export type CardNumberType<T extends ITypeMap> = (
+  export type CardNumberResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type CountryType<T extends ITypeMap> = (
+  export type CountryResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type ExpiresOnMonthType<T extends ITypeMap> = (
+  export type ExpiresOnMonthResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type ExpiresOnYearType<T extends ITypeMap> = (
+  export type ExpiresOnYearResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type FirstNameType<T extends ITypeMap> = (
+  export type FirstNameResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type LastNameType<T extends ITypeMap> = (
+  export type LastNameResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type PaymentAccountType<T extends ITypeMap> = (
+  export type PaymentAccountResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2156,14 +2156,14 @@ export namespace CreditCardInformationResolvers {
     | null
     | Promise<T[\\"PaymentAccountParent\\"] | null>;
 
-  export type PostalCodeType<T extends ITypeMap> = (
+  export type PostalCodeResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type SecurityCodeType<T extends ITypeMap> = (
+  export type SecurityCodeResolver<T extends ITypeMap> = (
     parent: T[\\"CreditCardInformationParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2244,28 +2244,28 @@ export namespace CreditCardInformationResolvers {
 }
 
 export namespace MessageResolvers {
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"MessageParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type DeliveredAtType<T extends ITypeMap> = (
+  export type DeliveredAtResolver<T extends ITypeMap> = (
     parent: T[\\"MessageParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"MessageParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type ReadAtType<T extends ITypeMap> = (
+  export type ReadAtResolver<T extends ITypeMap> = (
     parent: T[\\"MessageParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2301,91 +2301,91 @@ export namespace MessageResolvers {
 }
 
 export namespace PricingResolvers {
-  export type AverageMonthlyType<T extends ITypeMap> = (
+  export type AverageMonthlyResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type AverageWeeklyType<T extends ITypeMap> = (
+  export type AverageWeeklyResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type BasePriceType<T extends ITypeMap> = (
+  export type BasePriceResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type CleaningFeeType<T extends ITypeMap> = (
+  export type CleaningFeeResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
-  export type CurrencyType<T extends ITypeMap> = (
+  export type CurrencyResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"CURRENCYParent\\"] | null | Promise<T[\\"CURRENCYParent\\"] | null>;
 
-  export type ExtraGuestsType<T extends ITypeMap> = (
+  export type ExtraGuestsResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type MonthlyDiscountType<T extends ITypeMap> = (
+  export type MonthlyDiscountResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
-  export type PerNightType<T extends ITypeMap> = (
+  export type PerNightResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type SecurityDepositType<T extends ITypeMap> = (
+  export type SecurityDepositResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
-  export type SmartPricingType<T extends ITypeMap> = (
+  export type SmartPricingResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type WeekendPricingType<T extends ITypeMap> = (
+  export type WeekendPricingResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | null | Promise<number | null>;
 
-  export type WeeklyDiscountType<T extends ITypeMap> = (
+  export type WeeklyDiscountResolver<T extends ITypeMap> = (
     parent: T[\\"PricingParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2475,14 +2475,14 @@ export namespace PricingResolvers {
 }
 
 export namespace PlaceViewsResolvers {
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceViewsParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type LastWeekType<T extends ITypeMap> = (
+  export type LastWeekResolver<T extends ITypeMap> = (
     parent: T[\\"PlaceViewsParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2506,28 +2506,28 @@ export namespace PlaceViewsResolvers {
 }
 
 export namespace GuestRequirementsResolvers {
-  export type GovIssuedIdType<T extends ITypeMap> = (
+  export type GovIssuedIdResolver<T extends ITypeMap> = (
     parent: T[\\"GuestRequirementsParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type GuestTripInformationType<T extends ITypeMap> = (
+  export type GuestTripInformationResolver<T extends ITypeMap> = (
     parent: T[\\"GuestRequirementsParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"GuestRequirementsParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type RecommendationsFromOtherHostsType<T extends ITypeMap> = (
+  export type RecommendationsFromOtherHostsResolver<T extends ITypeMap> = (
     parent: T[\\"GuestRequirementsParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2563,42 +2563,42 @@ export namespace GuestRequirementsResolvers {
 }
 
 export namespace PoliciesResolvers {
-  export type CheckInEndTimeType<T extends ITypeMap> = (
+  export type CheckInEndTimeResolver<T extends ITypeMap> = (
     parent: T[\\"PoliciesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type CheckInStartTimeType<T extends ITypeMap> = (
+  export type CheckInStartTimeResolver<T extends ITypeMap> = (
     parent: T[\\"PoliciesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type CheckoutTimeType<T extends ITypeMap> = (
+  export type CheckoutTimeResolver<T extends ITypeMap> = (
     parent: T[\\"PoliciesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => number | Promise<number>;
 
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"PoliciesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"PoliciesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type UpdatedAtType<T extends ITypeMap> = (
+  export type UpdatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"PoliciesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2646,63 +2646,63 @@ export namespace PoliciesResolvers {
 }
 
 export namespace HouseRulesResolvers {
-  export type AdditionalRulesType<T extends ITypeMap> = (
+  export type AdditionalRulesResolver<T extends ITypeMap> = (
     parent: T[\\"HouseRulesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | null | Promise<string | null>;
 
-  export type CreatedAtType<T extends ITypeMap> = (
+  export type CreatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"HouseRulesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => T[\\"DateTimeParent\\"] | Promise<T[\\"DateTimeParent\\"]>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"HouseRulesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type PartiesAndEventsAllowedType<T extends ITypeMap> = (
+  export type PartiesAndEventsAllowedResolver<T extends ITypeMap> = (
     parent: T[\\"HouseRulesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
-  export type PetsAllowedType<T extends ITypeMap> = (
+  export type PetsAllowedResolver<T extends ITypeMap> = (
     parent: T[\\"HouseRulesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
-  export type SmokingAllowedType<T extends ITypeMap> = (
+  export type SmokingAllowedResolver<T extends ITypeMap> = (
     parent: T[\\"HouseRulesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
-  export type SuitableForChildrenType<T extends ITypeMap> = (
+  export type SuitableForChildrenResolver<T extends ITypeMap> = (
     parent: T[\\"HouseRulesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
-  export type SuitableForInfantsType<T extends ITypeMap> = (
+  export type SuitableForInfantsResolver<T extends ITypeMap> = (
     parent: T[\\"HouseRulesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | null | Promise<boolean | null>;
 
-  export type UpdatedAtType<T extends ITypeMap> = (
+  export type UpdatedAtResolver<T extends ITypeMap> = (
     parent: T[\\"HouseRulesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
@@ -2768,287 +2768,287 @@ export namespace HouseRulesResolvers {
 }
 
 export namespace AmenitiesResolvers {
-  export type AirConditioningType<T extends ITypeMap> = (
+  export type AirConditioningResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type BabyBathType<T extends ITypeMap> = (
+  export type BabyBathResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type BabyMonitorType<T extends ITypeMap> = (
+  export type BabyMonitorResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type BabysitterRecommendationsType<T extends ITypeMap> = (
+  export type BabysitterRecommendationsResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type BathtubType<T extends ITypeMap> = (
+  export type BathtubResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type BreakfastType<T extends ITypeMap> = (
+  export type BreakfastResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type BuzzerWirelessIntercomType<T extends ITypeMap> = (
+  export type BuzzerWirelessIntercomResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type CableTvType<T extends ITypeMap> = (
+  export type CableTvResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type ChangingTableType<T extends ITypeMap> = (
+  export type ChangingTableResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type ChildrensBooksAndToysType<T extends ITypeMap> = (
+  export type ChildrensBooksAndToysResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type ChildrensDinnerwareType<T extends ITypeMap> = (
+  export type ChildrensDinnerwareResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type CribType<T extends ITypeMap> = (
+  export type CribResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type DoormanType<T extends ITypeMap> = (
+  export type DoormanResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type DryerType<T extends ITypeMap> = (
+  export type DryerResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type ElevatorType<T extends ITypeMap> = (
+  export type ElevatorResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type EssentialsType<T extends ITypeMap> = (
+  export type EssentialsResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type FamilyKidFriendlyType<T extends ITypeMap> = (
+  export type FamilyKidFriendlyResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type FreeParkingOnPremisesType<T extends ITypeMap> = (
+  export type FreeParkingOnPremisesResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type FreeParkingOnStreetType<T extends ITypeMap> = (
+  export type FreeParkingOnStreetResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type GymType<T extends ITypeMap> = (
+  export type GymResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type HairDryerType<T extends ITypeMap> = (
+  export type HairDryerResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type HangersType<T extends ITypeMap> = (
+  export type HangersResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type HeatingType<T extends ITypeMap> = (
+  export type HeatingResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type HotTubType<T extends ITypeMap> = (
+  export type HotTubResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type IdType<T extends ITypeMap> = (
+  export type IdResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => string | Promise<string>;
 
-  export type IndoorFireplaceType<T extends ITypeMap> = (
+  export type IndoorFireplaceResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type InternetType<T extends ITypeMap> = (
+  export type InternetResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type IronType<T extends ITypeMap> = (
+  export type IronResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type KitchenType<T extends ITypeMap> = (
+  export type KitchenResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type LaptopFriendlyWorkspaceType<T extends ITypeMap> = (
+  export type LaptopFriendlyWorkspaceResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type PaidParkingOffPremisesType<T extends ITypeMap> = (
+  export type PaidParkingOffPremisesResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type PetsAllowedType<T extends ITypeMap> = (
+  export type PetsAllowedResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type PoolType<T extends ITypeMap> = (
+  export type PoolResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type PrivateEntranceType<T extends ITypeMap> = (
+  export type PrivateEntranceResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type ShampooType<T extends ITypeMap> = (
+  export type ShampooResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type SmokingAllowedType<T extends ITypeMap> = (
+  export type SmokingAllowedResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type SuitableForEventsType<T extends ITypeMap> = (
+  export type SuitableForEventsResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type TvType<T extends ITypeMap> = (
+  export type TvResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type WasherType<T extends ITypeMap> = (
+  export type WasherResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type WheelchairAccessibleType<T extends ITypeMap> = (
+  export type WheelchairAccessibleResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],
     info: GraphQLResolveInfo
   ) => boolean | Promise<boolean>;
 
-  export type WirelessInternetType<T extends ITypeMap> = (
+  export type WirelessInternetResolver<T extends ITypeMap> = (
     parent: T[\\"AmenitiesParent\\"],
     args: {},
     ctx: T[\\"Context\\"],


### PR DESCRIPTION
- [x] Move input type interfaces within the namespace
- [x] Rename XType -> XResolvers because they are resolvers and were inadvertently renamed to `XType` in this PR https://github.com/prisma/graphql-resolver-codegen/pull/37/files when we were constructing the types for equivalent of "GraphQL type". Only one change was necessary but two were made. 