### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+## Description
+<!-- Describe the bug in details -->
+
+## Steps to reproduce
+<!-- What are the steps to reproduce this bug? List them. -->
+
+## Expected results
+<!-- Example: No error is thrown -->
+
+## Actual results
+<!-- Example: Error is thrown -->
+
+## Versions
+<!--
+Check your graphql-resolver-codegen by running:
+`graphql-resolver-codegen --version`
+-->
+- graphql-resolver-codegen:
+- OS name and version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!-- Please, enter a clear and meaningful title for your feature request. Thanks! -->
+
+## Description
+<!-- Give at least some information about the need and value of this request -->
+
+## Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Generate TS Resolvers
 
+### Support
+[Create a feature request](https://github.com/prisma/graphql-resolver-codegen/issues/new?template=feature_request.md&labels=enhancement)
+
+[Create a bug report](https://github.com/prisma/graphql-resolver-codegen/issues/new?template=bug_report.md&labels=bug)
+
 ### Feature
 
 1. Autogenerate resolver types


### PR DESCRIPTION
Fixes #61.

- Added issue templates for bug report and feature request
- Added shortcuts on README to easily create new issues using the implemented templates