### PR TITLE
Update the link to examples directory in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Note: while using `scaffold`, typemap.ts will always be generated irrespective o
 
 Not the `scaffold` command take an additional argument `i` which adds import for generated `interfaces` in scaffolded code.
 
-To see an example in action, please open the [`example`](https://github.com/prisma/graphql-resolver-codegen/tree/master/example) directory.
+To see an example in action, please open the [`examples`](https://github.com/prisma/graphql-resolver-codegen/tree/master/examples) directory.
 
 ### Design Decisions
 


### PR DESCRIPTION
The existing URL to example directory was redirecting to 404 Not Found, just updated it with the correct URL